### PR TITLE
Pydantic models

### DIFF
--- a/examples/Papers.ipynb
+++ b/examples/Papers.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "patient-lease",
+   "id": "guilty-cooking",
    "metadata": {},
    "source": [
     "# Papers: retrieve paper metadata"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "fresh-court",
+   "id": "explicit-float",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "administrative-blank",
+   "id": "unlikely-synthesis",
    "metadata": {
     "tags": []
    },
@@ -30,7 +30,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-03-04 15:31:16,797 - Papers - Calling https://api.scite.ai/papers/10.1093/oxfordhb/9780199646135.013.7\n"
+      "2021-03-04 23:41:38,431 - Papers - Calling https://api.scite.ai/papers/10.1093/oxfordhb/9780199646135.013.7\n"
      ]
     },
     {
@@ -63,14 +63,14 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "average-vehicle",
+   "id": "impossible-basket",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-03-04 15:31:26,122 - Papers - Calling https://api.scite.ai/papers with a payload of 2 papers\n"
+      "2021-03-04 23:42:59,638 - Papers - Calling https://api.scite.ai/papers with a payload of 2 papers\n"
      ]
     },
     {
@@ -117,8 +117,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "classical-redhead",
+   "execution_count": 5,
+   "id": "tough-decline",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValidationError",
+     "evalue": "1 validation error for DOIs\nids -> 0 -> id\n  string does not match regex \"^10\\.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$\" (type=value_error.str.regex; pattern=^10\\.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValidationError\u001b[0m                           Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-5-52856866f158>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mDOIs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m\"10.1234\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"10.1093/oxfordhb/9780199646135.013.7\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mpapers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_papers\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mDOIs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/github/scite-wrapper/scite/papers.py\u001b[0m in \u001b[0;36mget_papers\u001b[0;34m(dois)\u001b[0m\n\u001b[1;32m     63\u001b[0m     \"\"\"\n\u001b[1;32m     64\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdois\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mDOIs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 65\u001b[0;31m         \u001b[0mitems\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mDOIs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mids\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m{\u001b[0m\u001b[0;34m\"id\"\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mitem\u001b[0m\u001b[0;34m}\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mitem\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mdois\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     66\u001b[0m         \u001b[0mdois\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mid\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mitem\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mitems\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mids\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     67\u001b[0m     \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdebug\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"Calling https://api.scite.ai/papers with a payload of {len(dois)} papers\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/github/scite-wrapper/env/lib/python3.8/site-packages/pydantic/main.cpython-38-x86_64-linux-gnu.so\u001b[0m in \u001b[0;36mpydantic.main.BaseModel.__init__\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mValidationError\u001b[0m: 1 validation error for DOIs\nids -> 0 -> id\n  string does not match regex \"^10\\.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$\" (type=value_error.str.regex; pattern=^10\\.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$)"
+     ]
+    }
+   ],
+   "source": [
+    "DOIs = [\"10.1234\", \"10.1093/oxfordhb/9780199646135.013.7\"]\n",
+    "papers.get_papers(DOIs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "medieval-knight",
    "metadata": {
     "tags": []
    },
@@ -127,7 +152,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2021-03-04 15:32:21,955 - Papers - Calling https://api.scite.ai/papers/10.1017/CBO9780511628283.008\n"
+      "2021-03-04 23:45:52,195 - Papers - Calling https://api.scite.ai/papers/10.1017/CBO9780511628283.008\n"
      ]
     },
     {
@@ -3149,7 +3174,7 @@
        "   'journal': 'European Political Science Review'}}}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 # external
 requests==2.25.1
 ratelimit==2.2.1
+pydantic==1.8.1

--- a/scite/models.py
+++ b/scite/models.py
@@ -1,7 +1,19 @@
 # -*- coding: utf-8 -*-
-from typing import Any, AnyStr, Dict, List
+from typing import List
+from pydantic import BaseModel, constr, validator
 
 
-DOI = AnyStr
-DOIs = List[DOI]
-JSON = Dict[str, Any]
+class DOI(BaseModel):
+    id: constr(regex=r"^10\.\d{4,9}/[-._;()/:a-zA-Z0-9]+$")
+
+
+class DOIs(BaseModel):
+    ids: List[DOI]
+
+    @validator("ids")
+    def check_size(cls, v):
+        size = len(v)
+        if size < 1 or size > 500:
+            raise ValueError("API takes up to 500 DOIs per request.")
+        return v
+

--- a/scite/papers.py
+++ b/scite/papers.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
-from .models import DOI, DOIs, JSON 
+from .models import DOI, DOIs
 from .http_utils import remote_call
 from .logging_utils import set_logger
 
 logger = set_logger("Papers")
 
 
-def get_paper(doi: DOI) -> JSON:
-    """Get paper metadata for DOI. 
+def get_paper(doi: DOI):
+    """Get paper metadata for DOI.
 
-    
+
     Examples
     --------
     >>> doi = "10.1017/cbo9780511628283.008"
@@ -19,11 +19,13 @@ def get_paper(doi: DOI) -> JSON:
     -----
     Docs: https://api.scite.ai/docs#operation/get_paper_papers__doi__get
     """
+    if not isinstance(doi, DOI):
+        doi = DOI(id=doi).id
     logger.debug(f"Calling https://api.scite.ai/papers/{doi}")
     return remote_call(endpoint=f"papers/{doi}")
 
 
-def get_papers_by_target(target_doi: DOI) -> JSON:
+def get_papers_by_target(target_doi: DOI):
     """Get papers citing a given DOI.
 
 
@@ -36,15 +38,17 @@ def get_papers_by_target(target_doi: DOI) -> JSON:
     -----
     Docs: https://api.scite.ai/docs#operation/get_target_sources_papers_sources__target_doi__get
     """
+    if not isinstance(target_doi, DOI):
+        target_doi = DOI(id=target_doi).id
     logger.debug(f"Calling https://api.scite.ai/papers/{target_doi}")
     return remote_call(endpoint=f"papers/sources/{target_doi}")
 
 
-def get_papers(dois: DOIs) -> JSON:
+def get_papers(dois: DOIs):
     """Get multiple papers.
     Up to 500 papers can be requested at once by passing in a list of DOIs
 
-    
+
     Examples
     --------
     >>> DOIS = [
@@ -57,5 +61,9 @@ def get_papers(dois: DOIs) -> JSON:
     -----
     Docs: https://api.scite.ai/docs#operation/get_papers_papers_get
     """
+    if not isinstance(dois, DOIs):
+        items = DOIs(ids=[{"id": item} for item in dois])
+        dois = {item.id for item in items.ids}
     logger.debug(f"Calling https://api.scite.ai/papers with a payload of {len(dois)} papers")
-    return remote_call(endpoint="papers", payload=dois)
+    return remote_call(endpoint="papers", payload=[*dois])
+


### PR DESCRIPTION
Replaced `typing` custom type annotations with `pydantic` models. 
This should make parsing more reliable (at cost of making code harder to follow).  